### PR TITLE
Split forecasters and persisters from main

### DIFF
--- a/forecast/darksy.go
+++ b/forecast/darksy.go
@@ -1,0 +1,36 @@
+package forecast
+
+import (
+	"github.com/fishnix/darksky"
+)
+
+// DarkSkyForecast defines the struct for getting forecast data from the Darksky API
+type DarkSkyForecast struct {
+	Lat     string
+	Long    string
+	Key     string
+	Exclude []string
+}
+
+// Initialize prepares the BoltDB for persisting
+func (d DarkSkyForecast) Initialize() error {
+	return nil
+}
+
+// Fetch gets the forecast from the darkski api
+// TODO: parse this into a common format, should return nixlight.Forecasts
+func (d DarkSkyForecast) Fetch() (*darksky.Forecast, error) {
+	client := d.buildAPIClient()
+	return client.GetForecast()
+}
+
+func (d DarkSkyForecast) buildAPIClient() darksky.APIClient {
+	apiClient := darksky.APIClient{
+		Lat:     d.Lat,
+		Long:    d.Long,
+		Key:     d.Key,
+		Exclude: d.Exclude,
+	}
+
+	return apiClient
+}

--- a/forecast/fetcher.go
+++ b/forecast/fetcher.go
@@ -1,0 +1,41 @@
+package forecast
+
+import (
+	"log"
+	"time"
+
+	"github.com/fishnix/darksky"
+)
+
+// Fetcher is an interface for Fetching forecast data
+type Fetcher interface {
+	Initialize() error
+	Fetch() (*darksky.Forecast, error)
+}
+
+// StartFetcher takes a Fetcher and a duration and creates a goroutine that returns
+// forecast data over a channel and a control channel for killing the goroutine
+func StartFetcher(f Fetcher, timer time.Duration) (<-chan *darksky.Forecast, chan string) {
+	controlChannel := make(chan string)
+	forecastChannel := make(chan *darksky.Forecast)
+
+	ticker := time.NewTicker(timer)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				forecast, err := f.Fetch()
+				if err != nil {
+					log.Println("[ERROR] unable to get forecast", err)
+				}
+				forecastChannel <- forecast
+			case <-controlChannel:
+				close(forecastChannel)
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+
+	return forecastChannel, controlChannel
+}

--- a/light/control.go
+++ b/light/control.go
@@ -4,5 +4,5 @@ package light
 // controller and to set the Brightness(int) of a light
 type Controller interface {
 	Start() error
-	Brightness(int) error
+	SetBrightness(int) error
 }

--- a/light/dummy.go
+++ b/light/dummy.go
@@ -4,21 +4,19 @@ import (
 	"log"
 )
 
+// Dummy is a dummy light controller
 type Dummy struct {
 	Name string
 }
 
+// Start initializes the dummy light controller
 func (d *Dummy) Start() error {
 	log.Printf("Starting dummy light %s controller\n", d.Name)
-
-	if l, ok := interface{}(d).(Controller); ok {
-		log.Printf("It looks like %+v satisfies the Controller interface!", l)
-	}
-
 	return nil
 }
 
-func (d *Dummy) Brightness(b int) error {
+// SetBrightness sets the brightness level of the dummy light
+func (d *Dummy) SetBrightness(b int) error {
 	log.Printf("Setting dummy light %s's brightness to %d\n", d.Name, b)
 	return nil
 }

--- a/nixlight.go
+++ b/nixlight.go
@@ -1,18 +1,17 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
 	"os"
 	"time"
 
-	"github.com/boltdb/bolt"
-	"github.com/fishnix/darksky"
 	"github.com/fishnix/nixlight/common"
+	"github.com/fishnix/nixlight/forecast"
 	"github.com/fishnix/nixlight/light"
 	"github.com/fishnix/nixlight/nixlight"
+	"github.com/fishnix/nixlight/persist"
 )
 
 var (
@@ -40,34 +39,34 @@ func main() {
 	configuration := common.ReadConfig(config)
 	configuration.Print()
 
-	// START CONSUMERS
-	persister, _ := startPersister(configuration.DB)
-	// END CONSUMERS
+	// Start Persisters and Consumers of forecast data
+	db := persist.BoltDbPersister{File: configuration.DB}
+	persister, _ := persist.StartPersister(db)
 
-	// START FETCHER
-	apiClient, err := buildAPIClient(configuration)
-	if err != nil {
-		log.Fatalln("[ERROR] unable to initialize the DarkSky API Client", err)
+	ds := forecast.DarkSkyForecast{
+		Lat:     configuration.DarkSkyClient.Lat,
+		Long:    configuration.DarkSkyClient.Long,
+		Key:     configuration.DarkSkyClient.Key,
+		Exclude: []string{"hourly", "minutely"},
 	}
 
 	timer, err := time.ParseDuration(configuration.Timer)
 	if err != nil {
 		log.Fatalln("[ERROR] unable to parse configuration Timer", err)
 	}
-
 	log.Println("[INFO] Updating every", configuration.Timer)
-	fetcher, _ := startFetcher(apiClient, timer)
-	// END FETCHER
 
-	// START FANOUT
+	// Start the forecast fetcher
+	fetcher, _ := forecast.StartFetcher(ds, timer)
+
+	// Fanout fetcher to all consumers/persisters
 	for f := range fetcher {
 		persister <- f
 	}
-	// END COLLECTOR
 
 	dummy := light.Dummy{Name: "Dummy Light"}
 	dummy.Start()
-	dummy.Brightness(123)
+	dummy.SetBrightness(123)
 
 	if l, ok := interface{}(dummy).(light.Controller); ok {
 		log.Printf("It looks like %+v satisfies the light.Controller interface!", l)
@@ -78,130 +77,6 @@ func main() {
 		time.Sleep(time.Millisecond * 10000)
 	}
 	// close(quit)
-}
-
-func buildAPIClient(configuration common.Config) (darksky.APIClient, error) {
-	apiClient := darksky.APIClient{
-		Lat:     configuration.DarkSkyClient.Lat,
-		Long:    configuration.DarkSkyClient.Long,
-		Key:     configuration.DarkSkyClient.Key,
-		Exclude: []string{"hourly", "minutely"},
-	}
-
-	return apiClient, nil
-}
-
-// startFetcher takes the darksky client and creates a goroutine that returns
-// forecast data over a channel and opens a control channel for killing the goroutine
-func startFetcher(client darksky.APIClient, timer time.Duration) (<-chan *darksky.Forecast, chan string) {
-	controlChannel := make(chan string)
-	forecastChannel := make(chan *darksky.Forecast)
-
-	ticker := time.NewTicker(timer)
-	go func() {
-		for {
-			select {
-			case <-ticker.C:
-				forecast, err := client.GetForecast()
-				if err != nil {
-					log.Println("[ERROR] unable to get forecast", err)
-				}
-				forecastChannel <- forecast
-			case <-controlChannel:
-				close(forecastChannel)
-				ticker.Stop()
-				return
-			}
-		}
-	}()
-
-	return forecastChannel, controlChannel
-}
-
-// startPersister takes the boltdb file and starts a goroutine that receives forecast
-// data over a channel and opens a control channel for killing the goroutine
-func startPersister(file string) (chan *darksky.Forecast, chan string) {
-	initializeDB(file)
-	controlChannel := make(chan string)
-	forecastChannel := make(chan *darksky.Forecast)
-	go func() {
-		for {
-			select {
-			case f := <-forecastChannel:
-				log.Println("[INFO] recieved forecast data on persister channel")
-				log.Printf("Forecast: %+v", f)
-				err := persistData(file, f)
-				if err != nil {
-					log.Println("[ERROR] unable to perist data:", err)
-				}
-			case <-controlChannel:
-				close(forecastChannel)
-				return
-			}
-		}
-	}()
-
-	return forecastChannel, controlChannel
-}
-
-func initializeDB(file string) {
-	// open and/or create a boltdb
-	db, err := bolt.Open(file, 0600, &bolt.Options{Timeout: 1 * time.Second})
-	if err != nil {
-		log.Fatalln("[ERROR] unable to initialize the database", err)
-	}
-	defer db.Close()
-
-	// initialize the forecast buckets
-	initBucket(db, "DailyForecast")
-	initBucket(db, "Currently")
-}
-
-func initBucket(db *bolt.DB, bucket string) {
-	db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucketIfNotExists([]byte(bucket))
-		if err != nil {
-			log.Fatalln("[ERROR] unable to initialize bucket:", err)
-		}
-		return nil
-	})
-}
-
-func persistData(file string, forecast *darksky.Forecast) error {
-	db, err := bolt.Open(file, 0600, nil)
-	if err != nil {
-		log.Fatal("[ERROR] Unable to open boltdb", err)
-	}
-	defer db.Close()
-
-	cdata, err := json.Marshal(forecast.Currently)
-	if err != nil {
-		log.Println("[ERROR] Unable to marshall forecast into JSON:", err)
-	}
-	store(db, "Currently", []byte("now"), cdata)
-
-	for _, d := range forecast.Daily.Data {
-		tm := time.Unix(int64(d.Time), 0)
-		date := []byte(tm.String())
-		ddata, err := json.Marshal(d)
-		if err != nil {
-			log.Println("[ERROR] Unable to marshall forecast into JSON:", err)
-		}
-		store(db, "DailyForecast", date, ddata)
-	}
-
-	return nil
-}
-
-func store(db *bolt.DB, bucket string, key []byte, data []byte) error {
-	db.Update(func(tx *bolt.Tx) error {
-		var err error
-		b := tx.Bucket([]byte(bucket))
-		err = b.Put(key, data)
-		return err
-	})
-
-	return nil
 }
 
 func vers() {

--- a/persist/db.go
+++ b/persist/db.go
@@ -1,0 +1,84 @@
+package persist
+
+import (
+	"encoding/json"
+	"log"
+	"time"
+
+	"github.com/boltdb/bolt"
+	"github.com/fishnix/darksky"
+)
+
+// BoltDbPersister defines the struct for persisting data in BoltDB
+type BoltDbPersister struct {
+	File    string
+	Options bolt.Options
+}
+
+// Initialize prepares the BoltDB for persisting
+func (db BoltDbPersister) Initialize() error {
+	// open and/or create a boltdb
+	boltdb, err := bolt.Open(db.File, 0600, &db.Options)
+	if err != nil {
+		log.Println("[ERROR] unable to initialize the database", err)
+		return err
+	}
+	defer boltdb.Close()
+
+	// initialize the forecast buckets
+	initBucket(boltdb, "DailyForecast")
+	initBucket(boltdb, "Currently")
+	initBucket(boltdb, "Configuration")
+
+	return nil
+}
+
+// initBucket initializes a bucket in BoltDB
+func initBucket(db *bolt.DB, bucket string) {
+	db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte(bucket))
+		if err != nil {
+			log.Fatalln("[ERROR] unable to initialize bucket:", err)
+		}
+		return nil
+	})
+}
+
+// Persist is the interface method of Persister to write data to a bolt db
+func (db BoltDbPersister) Persist(forecast *darksky.Forecast) error {
+	boltdb, err := bolt.Open(db.File, 0600, &db.Options)
+	if err != nil {
+		log.Fatal("[ERROR] Unable to open boltdb", err)
+	}
+	defer boltdb.Close()
+
+	cdata, err := json.Marshal(forecast.Currently)
+	if err != nil {
+		log.Println("[ERROR] Unable to marshall forecast into JSON:", err)
+	}
+	store(boltdb, "Currently", []byte("now"), cdata)
+
+	for _, d := range forecast.Daily.Data {
+		tm := time.Unix(int64(d.Time), 0)
+		date := []byte(tm.String())
+		ddata, err := json.Marshal(d)
+		if err != nil {
+			log.Println("[ERROR] Unable to marshall forecast into JSON:", err)
+		}
+		store(boltdb, "DailyForecast", date, ddata)
+	}
+
+	return nil
+}
+
+// store does the boltdb Update
+func store(db *bolt.DB, bucket string, key []byte, data []byte) error {
+	db.Update(func(tx *bolt.Tx) error {
+		var err error
+		b := tx.Bucket([]byte(bucket))
+		err = b.Put(key, data)
+		return err
+	})
+
+	return nil
+}

--- a/persist/persister.go
+++ b/persist/persister.go
@@ -1,0 +1,43 @@
+package persist
+
+import (
+	"log"
+
+	"github.com/fishnix/darksky"
+)
+
+// Persister is an interface to persisting data from the darksky api
+type Persister interface {
+	Initialize() error
+	Persist(*darksky.Forecast) error
+}
+
+// StartPersister takes a persister and starts a goroutine that receives forecast
+// data over a channel and opens a control channel for killing the goroutine
+func StartPersister(p Persister) (chan *darksky.Forecast, chan string) {
+	err := p.Initialize()
+	if err != nil {
+		log.Fatalln("Error initializing persister", err)
+	}
+
+	controlChannel := make(chan string)
+	forecastChannel := make(chan *darksky.Forecast)
+	go func() {
+		for {
+			select {
+			case f := <-forecastChannel:
+				log.Println("[INFO] recieved forecast data on persister channel")
+				log.Printf("%+v", f)
+				err := p.Persist(f)
+				if err != nil {
+					log.Println("[ERROR] unable to perist data:", err)
+				}
+			case <-controlChannel:
+				close(forecastChannel)
+				return
+			}
+		}
+	}()
+
+	return forecastChannel, controlChannel
+}


### PR DESCRIPTION
Forecaster and Persister needed to be interfaces to allow for more
things to pull forecast data and for more ways to consume or persist
that data.  Currently Persister is fairly open, but Forecaster is still
passing around the darksky api client structs as data, this should be a
nixlight.Forecast at some point.